### PR TITLE
feat: add prunableToolsInjectionFrequency to gate prunable-tools list injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ DCP uses its own config file:
 >             //     "anthropic/claude-3-7-sonnet": "80%"
 >             // },
 >             // Additional tools to protect from pruning
-            >             "protectedTools": [],
+>             "protectedTools": [],
 >             // Minimum number of new tool calls AND prunable items before injecting
 >             // the prunable-tools list. Reduces cache invalidation on providers
 >             // with prefix-based or breakpoint-based caching (e.g. Anthropic, Vertex AI).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ LLM providers like Anthropic and OpenAI cache prompts based on exact prefix matc
 
 > **Note:** In testing, cache hit rates were approximately 80% with DCP enabled vs 85% without for most providers.
 
-**Tip:** If you use Anthropic or Vertex AI and want to preserve more cache hits, set `prunableToolsInjectionFrequency` to a value like `20`. This delays the prunable-tools list injection until enough new tool calls accumulate, reducing how often the injected context changes and invalidates the prefix cache.
+**Tip:** Set `prunableToolsInjectionFrequency` to a value like `20` to delay prunable-tools list injection until enough new tool calls accumulate. This reduces how often the injected context changes, preserving prompt cache across providers that use prefix matching or cache breakpoints (e.g. Anthropic, Vertex AI, OpenAI). It also causes prune/distill operations to be batched, reducing the number of conversation history mutations that invalidate cache.
 
 **Best use case:** Providers that count usage in requests, such as Github Copilot and Google Antigravity, have no negative price impact.
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,12 @@ DCP uses its own config file:
 >             //     "anthropic/claude-3-7-sonnet": "80%"
 >             // },
 >             // Additional tools to protect from pruning
-            > 			"protectedTools": [],
-            > 			// Minimum number of new tool calls AND prunable items before injecting
-            > 			// the prunable-tools list. Reduces Anthropic/Vertex AI cache invalidation.
-            > 			// 0 = inject every turn (default, backward-compatible)
-            > 			"prunableToolsInjectionFrequency": 0,
+            >             "protectedTools": [],
+>             // Minimum number of new tool calls AND prunable items before injecting
+>             // the prunable-tools list. Reduces cache invalidation on providers
+>             // with prefix-based or breakpoint-based caching (e.g. Anthropic, Vertex AI).
+>             // 0 = inject every turn (default, backward-compatible)
+>             "prunableToolsInjectionFrequency": 0,
 >         },
 >         // Distills key findings into preserved knowledge before removing raw content
 >         "distill": {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ LLM providers like Anthropic and OpenAI cache prompts based on exact prefix matc
 
 > **Note:** In testing, cache hit rates were approximately 80% with DCP enabled vs 85% without for most providers.
 
+**Tip:** If you use Anthropic or Vertex AI and want to preserve more cache hits, set `prunableToolsInjectionFrequency` to a value like `20`. This delays the prunable-tools list injection until enough new tool calls accumulate, reducing how often the injected context changes and invalidates the prefix cache.
+
 **Best use case:** Providers that count usage in requests, such as Github Copilot and Google Antigravity, have no negative price impact.
 
 **Best use cases:**
@@ -124,7 +126,11 @@ DCP uses its own config file:
 >             //     "anthropic/claude-3-7-sonnet": "80%"
 >             // },
 >             // Additional tools to protect from pruning
->             "protectedTools": [],
+            > 			"protectedTools": [],
+            > 			// Minimum number of new tool calls AND prunable items before injecting
+            > 			// the prunable-tools list. Reduces Anthropic/Vertex AI cache invalidation.
+            > 			// 0 = inject every turn (default, backward-compatible)
+            > 			"prunableToolsInjectionFrequency": 0,
 >         },
 >         // Distills key findings into preserved knowledge before removing raw content
 >         "distill": {

--- a/dcp.schema.json
+++ b/dcp.schema.json
@@ -157,6 +157,11 @@
                                     }
                                 ]
                             }
+                        },
+                        "prunableToolsInjectionFrequency": {
+                            "type": "number",
+                            "default": 0,
+                            "description": "Minimum number of new tool calls (since last prune/distill/compress) AND minimum number of prunable tool outputs required before injecting the prunable-tools list. 0 = inject every turn (default, backward-compatible). Higher values reduce Anthropic/Vertex AI prefix cache invalidation by injecting less frequently."
                         }
                     }
                 },

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -811,7 +811,9 @@ function mergeTools(
             ],
             contextLimit: override.settings?.contextLimit ?? base.settings.contextLimit,
             modelLimits: override.settings?.modelLimits ?? base.settings.modelLimits,
-            prunableToolsInjectionFrequency: override.settings?.prunableToolsInjectionFrequency ?? base.settings.prunableToolsInjectionFrequency,
+            prunableToolsInjectionFrequency:
+                override.settings?.prunableToolsInjectionFrequency ??
+                base.settings.prunableToolsInjectionFrequency,
         },
         distill: {
             permission: override.distill?.permission ?? base.distill.permission,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -347,25 +347,21 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     actual: `${tools.settings.nudgeFrequency} (will be clamped to 1)`,
                 })
             }
-            if (
-                tools.settings.prunableToolsInjectionFrequency !== undefined &&
-                typeof tools.settings.prunableToolsInjectionFrequency !== "number"
-            ) {
-                errors.push({
-                    key: "tools.settings.prunableToolsInjectionFrequency",
-                    expected: "number",
-                    actual: typeof tools.settings.prunableToolsInjectionFrequency,
-                })
-            }
-            if (
-                typeof tools.settings.prunableToolsInjectionFrequency === "number" &&
-                tools.settings.prunableToolsInjectionFrequency < 0
-            ) {
-                errors.push({
-                    key: "tools.settings.prunableToolsInjectionFrequency",
-                    expected: "non-negative number (>= 0)",
-                    actual: `${tools.settings.prunableToolsInjectionFrequency}`,
-                })
+            if (tools.settings.prunableToolsInjectionFrequency !== undefined) {
+                const freq = tools.settings.prunableToolsInjectionFrequency
+                if (typeof freq !== "number") {
+                    errors.push({
+                        key: "tools.settings.prunableToolsInjectionFrequency",
+                        expected: "number",
+                        actual: typeof freq,
+                    })
+                } else if (freq < 0) {
+                    errors.push({
+                        key: "tools.settings.prunableToolsInjectionFrequency",
+                        expected: "non-negative number (>= 0)",
+                        actual: `${freq}`,
+                    })
+                }
             }
             if (
                 tools.settings.protectedTools !== undefined &&

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -29,6 +29,7 @@ export interface ToolSettings {
     protectedTools: string[]
     contextLimit: number | `${number}%`
     modelLimits?: Record<string, number | `${number}%`>
+    prunableToolsInjectionFrequency?: number
 }
 
 export interface Tools {
@@ -120,6 +121,7 @@ export const VALID_CONFIG_KEYS = new Set([
     "tools.settings.protectedTools",
     "tools.settings.contextLimit",
     "tools.settings.modelLimits",
+    "tools.settings.prunableToolsInjectionFrequency",
     "tools.distill",
     "tools.distill.permission",
     "tools.distill.showDistillation",
@@ -343,6 +345,26 @@ export function validateConfigTypes(config: Record<string, any>): ValidationErro
                     key: "tools.settings.nudgeFrequency",
                     expected: "positive number (>= 1)",
                     actual: `${tools.settings.nudgeFrequency} (will be clamped to 1)`,
+                })
+            }
+            if (
+                tools.settings.prunableToolsInjectionFrequency !== undefined &&
+                typeof tools.settings.prunableToolsInjectionFrequency !== "number"
+            ) {
+                errors.push({
+                    key: "tools.settings.prunableToolsInjectionFrequency",
+                    expected: "number",
+                    actual: typeof tools.settings.prunableToolsInjectionFrequency,
+                })
+            }
+            if (
+                typeof tools.settings.prunableToolsInjectionFrequency === "number" &&
+                tools.settings.prunableToolsInjectionFrequency < 0
+            ) {
+                errors.push({
+                    key: "tools.settings.prunableToolsInjectionFrequency",
+                    expected: "non-negative number (>= 0)",
+                    actual: `${tools.settings.prunableToolsInjectionFrequency}`,
                 })
             }
             if (
@@ -793,6 +815,7 @@ function mergeTools(
             ],
             contextLimit: override.settings?.contextLimit ?? base.settings.contextLimit,
             modelLimits: override.settings?.modelLimits ?? base.settings.modelLimits,
+            prunableToolsInjectionFrequency: override.settings?.prunableToolsInjectionFrequency ?? base.settings.prunableToolsInjectionFrequency,
         },
         distill: {
             permission: override.distill?.permission ?? base.distill.permission,

--- a/lib/messages/inject.ts
+++ b/lib/messages/inject.ts
@@ -264,8 +264,11 @@ export const insertPruneToolContext = (
         : undefined
 
     if (state.lastToolPrune) {
-        logger.debug("Last tool was prune - injecting cooldown message")
-        contentParts.push(getCooldownMessage(config))
+        const threshold = config.tools.settings.prunableToolsInjectionFrequency ?? 0
+        if (threshold === 0) {
+            logger.debug("Last tool was prune - injecting cooldown message")
+            contentParts.push(getCooldownMessage(config))
+        }
     } else {
         let listInjected = false
         if (pruneOrDistillEnabled) {


### PR DESCRIPTION
## Summary

Add a new config option `prunableToolsInjectionFrequency` under `tools.settings` that gates the injection of the `<prunable-tools>` list behind two AND conditions:

1. **`nudgeCounter >= threshold`** — enough new tool calls since last prune/distill/compress
2. **`prunableItems.length >= threshold`** — enough prunable tool outputs accumulated

Default is `0` (inject every turn) for full backward compatibility.

## Problem

The `<prunable-tools>` list is injected every turn, causing:

- **Cache breakpoint invalidation** (Anthropic/Vertex AI): The list is appended to the last user message, and its content changes each turn (new tool calls accumulate). Since Anthropic's cache requires exact content match at each breakpoint, this likely causes the last-message cache breakpoint to miss every turn — only the system prompt breakpoint continues to hit, with the remaining context billed at full input pricing (up to 10x more expensive). For other providers with prefix-based caching, the impact is typically limited to the last message, but avoiding unnecessary invalidation is universally beneficial since caching behavior varies across providers.
- **Over-eager pruning leading to more cache destruction**: Modern LLMs (OpenAI Codex, Opus 4.6, etc.) proactively prune when they see the list, even without a nudge. Each prune/distill execution **mutates conversation history**, invalidating prefix cache on all providers. Reducing injection frequency causes prune operations to be batched (more items per operation, fewer operations total), reducing the number of cache-breaking history mutations across a session.

Related: Opencode-DCP/opencode-dynamic-context-pruning#368 (PRs welcome per @Tarquinen), Opencode-DCP/opencode-dynamic-context-pruning#320, Opencode-DCP/opencode-dynamic-context-pruning#339

## Design

- **Stateless**: Uses existing `nudgeCounter` (recomputed from message history each turn via `syncToolCache()`), so it's robust to session restart, rewind, and compaction — no new persisted state needed.
- **Single threshold**: Both conditions share the same value to keep config simple.
- **Independent of `nudgeFrequency`**: `nudgeFrequency` controls nudge text injection; `prunableToolsInjectionFrequency` controls list injection.
- **Nudge gating**: When `prunableToolsInjectionFrequency > 0`, regular nudge is only injected when the prunable-tools list is also injected. A nudge without the list would be meaningless.
- **Cooldown skip**: When `prunableToolsInjectionFrequency > 0`, the cooldown message (normally injected on the turn after prune/distill) is skipped. The list won't be injected again until the threshold is reached, so a cooldown is unnecessary and would only cause an extra cache-breaking injection.

### Why `nudgeCounter` is reused (not a separate counter)

`nudgeCounter` resets **only** on prune/distill/compress execution — it does **not** reset on nudge text insertion. This means it accurately represents "number of new tool calls since the last pruning operation," which is exactly the signal `prunableToolsInjectionFrequency` needs to gate on.

Introducing a separate counter would duplicate this exact same increment/reset logic across all these sites with no behavioral difference. If future requirements diverge (e.g., nudge needs its own reset timing), a separate counter can be introduced at that point.

### How `nudgeCounter` works

`syncToolCache()` recomputes `nudgeCounter` from scratch every turn by walking the full message history:

```
nudgeCounter = 0                       // reset at start of walk
for each message:
  for each tool-result part:
    if tool is prune/distill/compress:
      nudgeCounter = 0                 // reset — only count AFTER last pruning op
    else if not protected:
      nudgeCounter++                   // count non-protected tool calls
// result: tool calls since last prune/distill/compress
```

Additionally, `prune-shared.ts` and `compress.ts` reset `nudgeCounter = 0` **immediately after execution**. This is needed because `syncToolCache()` only runs at the **start of the next turn** — without these in-place resets, the counter would be stale for the remainder of the current turn (e.g., when `insertPruneToolContext` runs later in the same hook pipeline after a prune tool call).

### Behavior with `prunableToolsInjectionFrequency: 20`

```
Turn 1-19:  nudgeCounter < 20 → no list injection (cache preserved ✅)
Turn 20:    nudgeCounter=20, items>=20 → list injected (cache miss, but intentional)
Turn 21+:   list continues injecting until LLM prunes
After prune: nudgeCounter resets to 0, no cooldown injected → no injection for ~20 turns (cache preserved ✅)
```

## Config example

```jsonc
{
  "tools": {
    "settings": {
      "prunableToolsInjectionFrequency": 20
    }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `lib/config.ts` | Type, default, merge, key whitelist, validation |
| `lib/messages/inject.ts` | Extract `buildPrunableToolsLines()`, add threshold gating, gate nudge on list injection, skip cooldown when threshold > 0 |
| `dcp.schema.json` | Schema definition for new setting |
| `README.md` | Document new setting and cache optimization tip |

## Refactor note

`buildPrunableToolsList` is split into `buildPrunableToolsLines` (returns `string[]`) + existing `buildPrunableToolsList` (wraps into formatted string). This enables item count checks before wrapping, keeping the logic clean.